### PR TITLE
A couple fixes for snippets

### DIFF
--- a/snippets/core.cson
+++ b/snippets/core.cson
@@ -3994,18 +3994,18 @@ function ${1:hook}_form(\$node, &\$form_state) {
     'prefix': 'h.form_BASE_FORM_ID_alter'
     'body': '''
 /**
- * Implements hook_form_BASE_FORM_ID_alter() for ${1:BASE_FORM_ID}().
+ * Implements hook_form_BASE_FORM_ID_alter() for ${2:BASE_FORM_ID}().
  */
-function ${1:hook}_form_${1}_alter(&\$form, &\$form_state, \$form_id) {
+function ${1:hook}_form_$2_alter(&\$form, &\$form_state, \$form_id) {
 	$0
 }'''
   'h.form_FORM_ID_alter':
     'prefix': 'h.form_FORM_ID_alter'
     'body': '''
 /**
- * Implements hook_form_FORM_ID_alter() for ${1:FORM_ID}().
+ * Implements hook_form_FORM_ID_alter() for ${2:FORM_ID}().
  */
-function ${1:hook}_form_${1}_alter(&\$form, &\$form_state, \$form_id) {
+function ${1:hook}_form_$2_alter(&\$form, &\$form_state, \$form_id) {
 	$0
 }'''
   'h.form_alter':


### PR DESCRIPTION
This fixes a couple different things with the snippets:
1. The Doc comment blocks were not spaced correctly on expansion, which is now fixed. This is a majority of the changes as it affected almost all the hooks :grin: 
2. Also, fixed the tab stops on a couple form alter hooks that were using the same tab stop when they shouldn't
